### PR TITLE
Couple Admin Delete API, Album Admin API (Get, Album Post, Images Post, Update) 완성 (Dev backend 0227 ksy)

### DIFF
--- a/backend/.adminjs/.entry.js
+++ b/backend/.adminjs/.entry.js
@@ -1,1 +1,0 @@
-AdminJS.UserComponents = {}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,8 +9,6 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@adminjs/express": "^5.1.0",
-                "@adminjs/sequelize": "^3.0.0",
                 "@types/formidable": "^2.0.5",
                 "adminjs": "^6.8.6",
                 "bcrypt": "^5.1.0",
@@ -95,39 +93,6 @@
                 "react": "^18.1.0",
                 "react-dom": "^18.1.0",
                 "styled-components": "^5.3.5"
-            }
-        },
-        "node_modules/@adminjs/express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@adminjs/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-+mrtDmoAYA9R+/FTYWOLL48g005yrgcAWC2phdwqGzznIxGKSp2YERcfzdTI7Svtnlaal72/QW8Q3OhzJjVLzQ==",
-            "dependencies": {
-                "path-to-regexp": "^6.2.0"
-            },
-            "peerDependencies": {
-                "adminjs": ">=6.0.0",
-                "express": ">=4.16.4",
-                "express-formidable": "^1.2.0",
-                "express-session": ">=1.15.6",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@adminjs/express/node_modules/path-to-regexp": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-            "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
-        },
-        "node_modules/@adminjs/sequelize": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@adminjs/sequelize/-/sequelize-3.0.0.tgz",
-            "integrity": "sha512-vp5XxRubbcCqOqxs4B8vngcgCINLS9TvzEekpBemVyw4rceaLMBvO+C5CIOzOUbPwACSkTcvYoj7o+mF1x8MqA==",
-            "dependencies": {
-                "escape-regexp": "0.0.1",
-                "flat": "^5.0.0"
-            },
-            "peerDependencies": {
-                "adminjs": ">=6.0.0",
-                "sequelize": ">=4"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -5892,11 +5857,6 @@
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
         },
-        "node_modules/escape-regexp": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz",
-            "integrity": "sha512-jVgdsYRa7RKxTT6MKNC3gdT+BF0Gfhpel19+HMRZJC2L0PufB0XOBuXBoXj29NKHwuktnAXd1Z1lyiH/8vOTpw=="
-        },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -6317,60 +6277,10 @@
                 "node": ">= 0.10.0"
             }
         },
-        "node_modules/express-formidable": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/express-formidable/-/express-formidable-1.2.0.tgz",
-            "integrity": "sha512-w1vXjF3gb50UKTNkFaW8/4rqY4dUrKfZ1sAZzwAF9YxCAgj/29QZsycf71di0GkskrZOAkubk9pvGYfxyAMYiw==",
-            "peer": true,
-            "dependencies": {
-                "formidable": "^1.0.17"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/express-formidable/node_modules/formidable": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-            "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
-            "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
-            "peer": true,
-            "funding": {
-                "url": "https://ko-fi.com/tunnckoCore/commissions"
-            }
-        },
         "node_modules/express-query-boolean": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/express-query-boolean/-/express-query-boolean-2.0.0.tgz",
             "integrity": "sha512-4dU/1HPm8lkTPR12+HFUXqCarcsC19OKOkb4otLOuADfPYrQMaugPJkSmxNsqwmWYjozvT6vdTiqkgeBHkzOow=="
-        },
-        "node_modules/express-session": {
-            "version": "1.17.3",
-            "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
-            "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
-            "peer": true,
-            "dependencies": {
-                "cookie": "0.4.2",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "~2.0.0",
-                "on-headers": "~1.0.2",
-                "parseurl": "~1.3.3",
-                "safe-buffer": "5.2.1",
-                "uid-safe": "~2.1.5"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/express-session/node_modules/cookie": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -9045,15 +8955,6 @@
             "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
             "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
         },
-        "node_modules/random-bytes": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-            "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/randombytes": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
@@ -10428,18 +10329,6 @@
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
             "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
         },
-        "node_modules/uid-safe": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-            "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-            "peer": true,
-            "dependencies": {
-                "random-bytes": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -10929,30 +10818,6 @@
                 "react-text-mask": "^5.4.3",
                 "styled-system": "^5.1.5",
                 "text-mask-addons": "^3.8.0"
-            }
-        },
-        "@adminjs/express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@adminjs/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-+mrtDmoAYA9R+/FTYWOLL48g005yrgcAWC2phdwqGzznIxGKSp2YERcfzdTI7Svtnlaal72/QW8Q3OhzJjVLzQ==",
-            "requires": {
-                "path-to-regexp": "^6.2.0"
-            },
-            "dependencies": {
-                "path-to-regexp": {
-                    "version": "6.2.1",
-                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-                    "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
-                }
-            }
-        },
-        "@adminjs/sequelize": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@adminjs/sequelize/-/sequelize-3.0.0.tgz",
-            "integrity": "sha512-vp5XxRubbcCqOqxs4B8vngcgCINLS9TvzEekpBemVyw4rceaLMBvO+C5CIOzOUbPwACSkTcvYoj7o+mF1x8MqA==",
-            "requires": {
-                "escape-regexp": "0.0.1",
-                "flat": "^5.0.0"
             }
         },
         "@ampproject/remapping": {
@@ -15208,11 +15073,6 @@
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
         },
-        "escape-regexp": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz",
-            "integrity": "sha512-jVgdsYRa7RKxTT6MKNC3gdT+BF0Gfhpel19+HMRZJC2L0PufB0XOBuXBoXj29NKHwuktnAXd1Z1lyiH/8vOTpw=="
-        },
         "escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -15533,51 +15393,10 @@
                 "vary": "~1.1.2"
             }
         },
-        "express-formidable": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/express-formidable/-/express-formidable-1.2.0.tgz",
-            "integrity": "sha512-w1vXjF3gb50UKTNkFaW8/4rqY4dUrKfZ1sAZzwAF9YxCAgj/29QZsycf71di0GkskrZOAkubk9pvGYfxyAMYiw==",
-            "peer": true,
-            "requires": {
-                "formidable": "^1.0.17"
-            },
-            "dependencies": {
-                "formidable": {
-                    "version": "1.2.6",
-                    "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-                    "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
-                    "peer": true
-                }
-            }
-        },
         "express-query-boolean": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/express-query-boolean/-/express-query-boolean-2.0.0.tgz",
             "integrity": "sha512-4dU/1HPm8lkTPR12+HFUXqCarcsC19OKOkb4otLOuADfPYrQMaugPJkSmxNsqwmWYjozvT6vdTiqkgeBHkzOow=="
-        },
-        "express-session": {
-            "version": "1.17.3",
-            "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
-            "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
-            "peer": true,
-            "requires": {
-                "cookie": "0.4.2",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "~2.0.0",
-                "on-headers": "~1.0.2",
-                "parseurl": "~1.3.3",
-                "safe-buffer": "5.2.1",
-                "uid-safe": "~2.1.5"
-            },
-            "dependencies": {
-                "cookie": {
-                    "version": "0.4.2",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-                    "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-                    "peer": true
-                }
-            }
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -17602,12 +17421,6 @@
             "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
             "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
         },
-        "random-bytes": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-            "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-            "peer": true
-        },
         "randombytes": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
@@ -18579,15 +18392,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
             "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
-        },
-        "uid-safe": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-            "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-            "peer": true,
-            "requires": {
-                "random-bytes": "~1.0.0"
-            }
         },
         "unbox-primitive": {
             "version": "1.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,8 +31,6 @@
         "typescript": "^4.9.4"
     },
     "dependencies": {
-        "@adminjs/express": "^5.1.0",
-        "@adminjs/sequelize": "^3.0.0",
         "@types/formidable": "^2.0.5",
         "adminjs": "^6.8.6",
         "bcrypt": "^5.1.0",

--- a/backend/src/controller/album.admin.controller.ts
+++ b/backend/src/controller/album.admin.controller.ts
@@ -20,7 +20,7 @@ import {
 } from "../model/album.model";
 
 import logger from "../logger/logger";
-import { deleteFile, deleteFolder, getFiles, uploadFile } from "../util/firebase";
+import { deleteFile, deleteFolder, uploadFile } from "../util/firebase";
 import { Op, OrderItem, WhereOptions } from "sequelize";
 
 const FOLDER_NAME = "couples";
@@ -101,7 +101,6 @@ const controller = {
 
         return result;
     },
-    getAlbums: async (data: IRequestGet): Promise<void> => {},
     addAlbumFolder: async (data: ICreate): Promise<void> => {},
     addAlbums: async (cupId: string, albumId: number, files: File | File[]): Promise<void> => {},
     updateTitle: async (data: IRequestUpadteTitle): Promise<void> => {},

--- a/backend/src/controller/album.admin.controller.ts
+++ b/backend/src/controller/album.admin.controller.ts
@@ -1,0 +1,112 @@
+import dayjs from "dayjs";
+import { ListResult, StorageReference } from "firebase/storage";
+import { File } from "formidable";
+
+import ForbiddenError from "../error/forbidden";
+import NotFoundError from "../error/notFound";
+
+import sequelize from "../model";
+import {
+    Album,
+    ICreate,
+    IRequestGet,
+    IRequestUpadteThumbnail,
+    IRequestUpadteTitle,
+    IResponse,
+    IAlbumResponseWithCount,
+    SearchOptions,
+    PageOptions,
+    FilterOptions
+} from "../model/album.model";
+
+import logger from "../logger/logger";
+import { deleteFile, deleteFolder, getFiles, uploadFile } from "../util/firebase";
+import { Op, OrderItem, WhereOptions } from "sequelize";
+
+const FOLDER_NAME = "couples";
+
+const createSort = (sort: string): OrderItem => {
+    let result: OrderItem = ["createdTime", "DESC"];
+
+    switch (sort) {
+        case "r":
+            result = ["createdTime", "DESC"];
+            break;
+        case "o":
+            result = ["createdTime", "ASC"];
+            break;
+        case "cd":
+            result = ["cupId", "DESC"];
+            break;
+        case "ca":
+            result = ["cupId", "ASC"];
+            break;
+        default:
+            result = ["createdTime", "DESC"];
+            break;
+    }
+
+    return result;
+};
+
+const createWhere = (searchOptions: SearchOptions, filterOptions: FilterOptions): WhereOptions => {
+    let result: WhereOptions = {};
+
+    if (searchOptions.cupId) result["cupId"] = { [Op.like]: `%${searchOptions.cupId}%` };
+    if (filterOptions.fromDate && filterOptions.toDate) result["createdTime"] = { [Op.between]: [filterOptions.fromDate, filterOptions.toDate] };
+
+    return result;
+};
+
+const controller = {
+    /**
+     * 모든 Album Folder를 가져옵니다.
+     * ```typescript
+     * const pageOptions: PageOptions = {
+     *      count: 10,
+     *      page: 1,
+     *      sort: "r" | "o" | "cd" | "ca"
+     * };
+     * const searchOptions: SearchOptions = {
+     *      cupId: "AAABBB"
+     * };
+     * const filterOptions: FilterOptions = {
+     *      fromDate: "2023-03-01",
+     *      toDate: "2023-03-03"
+     * };
+     *
+     * const result: IAlbumResponseWithCount = await albumAdminController.getAlbumFolders(pageOptions, searchOptions, filterOptions);
+     * ```
+     * @param pageOptions {@link PageOptions}
+     * @param searchOptions {@link SearchOptions}
+     * @param filterOptions {@link FilterOptions}
+     * @returns A {@link IAlbumResponseWithCount}
+     */
+    getAlbumFolders: async (pageOptions: PageOptions, searchOptions: SearchOptions, filterOptions: FilterOptions): Promise<IAlbumResponseWithCount> => {
+        const offset: number = (pageOptions.page - 1) * pageOptions.count;
+        const sort: OrderItem = createSort(pageOptions.sort);
+        const where: WhereOptions = createWhere(searchOptions, filterOptions);
+
+        const { rows, count }: { rows: Album[]; count: number } = await Album.findAndCountAll({
+            where,
+            offset,
+            limit: pageOptions.count,
+            order: [sort]
+        });
+
+        const result: IAlbumResponseWithCount = {
+            albums: rows,
+            count: count
+        };
+
+        return result;
+    },
+    getAlbums: async (data: IRequestGet): Promise<void> => {},
+    addAlbumFolder: async (data: ICreate): Promise<void> => {},
+    addAlbums: async (cupId: string, albumId: number, files: File | File[]): Promise<void> => {},
+    updateTitle: async (data: IRequestUpadteTitle): Promise<void> => {},
+    updateThumbnail: async (data: IRequestUpadteThumbnail): Promise<void> => {},
+    deleteAlbum: async (cupId: string, albumId: number): Promise<void> => {}
+};
+
+export default controller;

--- a/backend/src/controller/album.controller.ts
+++ b/backend/src/controller/album.controller.ts
@@ -11,7 +11,7 @@ import { Album, ICreate, IRequestGet, IRequestUpadteThumbnail, IRequestUpadteTit
 import logger from "../logger/logger";
 import { deleteFile, deleteFolder, getFiles, uploadFile } from "../util/firebase";
 
-const folderName = "couples";
+const FOLDER_NAME = "couples";
 
 const controller = {
     /**
@@ -43,7 +43,7 @@ const controller = {
 
         if (!album) throw new NotFoundError("Not Found Albums");
 
-        const refName = `${folderName}/${data.cupId}/${data.albumId}`;
+        const refName = `${FOLDER_NAME}/${data.cupId}/${data.albumId}`;
         const firebaseResult: ListResult = await getFiles(refName, data.count, data.nextPageToken);
         const files: StorageReference[] = firebaseResult.items;
         const nextPageToken: string | undefined = firebaseResult.nextPageToken;
@@ -88,7 +88,7 @@ const controller = {
         if (files instanceof Array<File>) {
             for (let i = 0; i < files.length; i++) {
                 try {
-                    const path = `${folderName}/${cupId}/${albumId}/${dayjs().valueOf()}.${files[i].originalFilename}`;
+                    const path = `${FOLDER_NAME}/${cupId}/${albumId}/${dayjs().valueOf()}.${files[i].originalFilename}`;
                     await uploadFile(path, files[i].filepath);
                 } catch (error) {
                     logger.error(`Add album error and ignore => ${JSON.stringify(error)}`);
@@ -96,7 +96,7 @@ const controller = {
                 }
             }
         } else if (files instanceof File) {
-            const path = `${folderName}//${cupId}/${albumId}/${dayjs().valueOf()}.${files.originalFilename}`;
+            const path = `${FOLDER_NAME}//${cupId}/${albumId}/${dayjs().valueOf()}.${files.originalFilename}`;
             await uploadFile(path, files.filepath);
         }
 
@@ -124,7 +124,7 @@ const controller = {
      */
     updateThumbnail: async (data: IRequestUpadteThumbnail): Promise<void> => {
         let isUpload = false;
-        const path = `${folderName}/${data.cupId}/${data.albumId}/thumbnail/${dayjs().valueOf()}.${data.thumbnail.originalFilename}`;
+        const path = `${FOLDER_NAME}/${data.cupId}/${data.albumId}/thumbnail/${dayjs().valueOf()}.${data.thumbnail.originalFilename}`;
         const albumFolder = await Album.findByPk(data.albumId);
 
         if (!albumFolder) throw new NotFoundError("Not Found Error");
@@ -172,7 +172,7 @@ const controller = {
 
         if (albumFolder.thumbnail) await deleteFile(albumFolder.thumbnail);
 
-        const path = `${folderName}/${cupId}/${albumId}`;
+        const path = `${FOLDER_NAME}/${cupId}/${albumId}`;
         await deleteFolder(path);
         await albumFolder.destroy();
         logger.debug(`Success Deleted albums => ${cupId}, ${albumId}`);

--- a/backend/src/controller/album.controller.ts
+++ b/backend/src/controller/album.controller.ts
@@ -22,7 +22,7 @@ const controller = {
     getAlbumsFolder: async (cupId: string): Promise<Album[]> => {
         const albums: Album[] = await Album.findAll({
             where: { cupId: cupId },
-            attributes: { include: [[sequelize.fn("COUNT", sequelize.col("albumImages.album_id")), "count"]] },
+            attributes: { include: [[sequelize.fn("COUNT", sequelize.col("albumImages.album_id")), "total"]] },
             include: {
                 model: AlbumImage,
                 as: "albumImages",

--- a/backend/src/controller/album.controller.ts
+++ b/backend/src/controller/album.controller.ts
@@ -7,10 +7,9 @@ import NotFoundError from "../error/notFound";
 
 import sequelize from "../model";
 import { Album, ICreate, IRequestGet, IRequestUpadteThumbnail, IRequestUpadteTitle, IResponse } from "../model/album.model";
-import { ErrorImage } from "../model/errorImage.model";
 
 import logger from "../logger/logger";
-import { deleteFile, deleteFolder, getAllFiles, getFiles, uploadFile } from "../util/firebase";
+import { deleteFile, deleteFolder, getFiles, uploadFile } from "../util/firebase";
 
 const folderName = "couples";
 
@@ -175,19 +174,6 @@ const controller = {
 
         const path = `${folderName}/${cupId}/${albumId}`;
         await deleteFolder(path);
-        const images = await getAllFiles(path);
-
-        // 지워지지 않은 이미지가 존재할 시
-        if (images.items.length) {
-            images.items.forEach(async (image) => {
-                logger.warn(`Album Image not deleted : ${cupId} | ${albumId} => ${image.fullPath}`);
-
-                await ErrorImage.create({
-                    path: image.fullPath
-                });
-            });
-        }
-
         await albumFolder.destroy();
         logger.debug(`Success Deleted albums => ${cupId}, ${albumId}`);
     }

--- a/backend/src/controller/album.controller.ts
+++ b/backend/src/controller/album.controller.ts
@@ -171,8 +171,6 @@ const controller = {
         if (!albumFolder) throw new NotFoundError("Not Found Error");
         else if (albumFolder.cupId !== cupId) throw new ForbiddenError("Forbidden Error");
 
-        await albumFolder.destroy();
-
         if (albumFolder.thumbnail) await deleteFile(albumFolder.thumbnail);
 
         const path = `${folderName}/${cupId}/${albumId}`;
@@ -190,6 +188,7 @@ const controller = {
             });
         }
 
+        await albumFolder.destroy();
         logger.debug(`Success Deleted albums => ${cupId}, ${albumId}`);
     }
 };

--- a/backend/src/controller/album.controller.ts
+++ b/backend/src/controller/album.controller.ts
@@ -1,5 +1,4 @@
 import dayjs from "dayjs";
-import { ListResult, StorageReference } from "firebase/storage";
 import { File } from "formidable";
 
 import ForbiddenError from "../error/forbidden";
@@ -9,7 +8,8 @@ import sequelize from "../model";
 import { Album, ICreate, IRequestGet, IRequestUpadteThumbnail, IRequestUpadteTitle, IResponse } from "../model/album.model";
 
 import logger from "../logger/logger";
-import { deleteFile, deleteFolder, getFiles, uploadFile } from "../util/firebase";
+import { deleteFile, deleteFolder, uploadFile } from "../util/firebase";
+import { AlbumImage } from "../model/albnmImage.model";
 
 const FOLDER_NAME = "couples";
 
@@ -21,7 +21,14 @@ const controller = {
      */
     getAlbumsFolder: async (cupId: string): Promise<Album[]> => {
         const albums: Album[] = await Album.findAll({
-            where: { cupId: cupId }
+            where: { cupId: cupId },
+            attributes: { include: [[sequelize.fn("COUNT", sequelize.col("albumImages.album_id")), "count"]] },
+            include: {
+                model: AlbumImage,
+                as: "albumImages",
+                attributes: []
+            },
+            group: "Album.album_id"
         });
 
         if (albums.length <= 0) throw new NotFoundError("Not Found Albums");
@@ -35,31 +42,20 @@ const controller = {
      */
     getAlbums: async (data: IRequestGet): Promise<IResponse> => {
         const album: Album | null = await Album.findOne({
-            where: {
-                cupId: data.cupId,
-                albumId: data.albumId
-            }
+            where: { cupId: data.cupId }
         });
 
         if (!album) throw new NotFoundError("Not Found Albums");
 
-        const refName = `${FOLDER_NAME}/${data.cupId}/${data.albumId}`;
-        const firebaseResult: ListResult = await getFiles(refName, data.count, data.nextPageToken);
-        const files: StorageReference[] = firebaseResult.items;
-        const nextPageToken: string | undefined = firebaseResult.nextPageToken;
-
-        if (files.length <= 0) throw new NotFoundError("Not Found Error");
-
-        const items: string[] = [];
-
-        files.forEach((file) => {
-            items.push(file.fullPath);
+        const { rows, count }: { rows: AlbumImage[]; count: number } = await AlbumImage.findAndCountAll({
+            where: { albumId: data.albumId },
+            attributes: { exclude: ["albumId"] }
         });
 
         const result: IResponse = {
             ...album.dataValues,
-            items: items,
-            nextPageToken: nextPageToken
+            images: rows,
+            total: count
         };
 
         return result;
@@ -86,21 +82,38 @@ const controller = {
         else if (albumFolder.cupId !== cupId) throw new ForbiddenError("Forbidden Error");
 
         if (files instanceof Array<File>) {
+            const transaction = await sequelize.transaction();
+
             for (let i = 0; i < files.length; i++) {
                 try {
                     const path = `${FOLDER_NAME}/${cupId}/${albumId}/${dayjs().valueOf()}.${files[i].originalFilename}`;
                     await uploadFile(path, files[i].filepath);
+
+                    await AlbumImage.create(
+                        {
+                            albumId: albumId,
+                            image: path
+                        },
+                        { transaction }
+                    );
                 } catch (error) {
                     logger.error(`Add album error and ignore => ${JSON.stringify(error)}`);
                     continue;
                 }
             }
+
+            transaction.commit();
         } else if (files instanceof File) {
             const path = `${FOLDER_NAME}//${cupId}/${albumId}/${dayjs().valueOf()}.${files.originalFilename}`;
             await uploadFile(path, files.filepath);
+
+            await AlbumImage.create({
+                albumId: albumId,
+                image: path
+            });
         }
 
-        logger.debug(`Success add albums => ${cupId}, ${albumId}, ${JSON.stringify(files)}`);
+        logger.debug(`Success add albums => ${cupId} | ${albumId} | ${JSON.stringify(files)}`);
     },
     /**
      * 앨범 폴더명을 수정합니다.

--- a/backend/src/controller/album.controller.ts
+++ b/backend/src/controller/album.controller.ts
@@ -159,7 +159,7 @@ const controller = {
 
             if (prevThumbnail) {
                 await deleteFile(prevThumbnail);
-                logger.debug(`Deleted already image => ${prevThumbnail}`);
+                logger.debug(`Deleted Previous thumbnail => ${prevThumbnail}`);
             }
 
             transaction.commit();

--- a/backend/src/controller/couple.admin.controller.ts
+++ b/backend/src/controller/couple.admin.controller.ts
@@ -151,14 +151,7 @@ const controller = {
             const transaction = await sequelize.transaction();
 
             try {
-                if (couple.thumbnail) {
-                    try {
-                        await deleteFile(couple.thumbnail!);
-                    } catch (error) {
-                        logger.warn(`User Image not deleted : ${couple.cupId} => ${couple.thumbnail}`);
-                        await ErrorImage.create({ path: couple.thumbnail! });
-                    }
-                }
+                if (couple.thumbnail) await deleteFile(couple.thumbnail!);
 
                 if (couple.albums) {
                     const albums: Album[] = await couple.albums!;

--- a/backend/src/controller/couple.controller.ts
+++ b/backend/src/controller/couple.controller.ts
@@ -201,7 +201,7 @@ const controller = {
             // Upload, DB Update를 하고나서 기존 이미지 지우기
             if (prevThumbnail && data.thumbnail) {
                 await deleteFile(prevThumbnail);
-                logger.debug(`Deleted already thumbnail => ${prevThumbnail}`);
+                logger.debug(`Deleted Previous thumbnail => ${prevThumbnail}`);
             }
         } catch (error) {
             // Firebase에는 업로드 되었지만 DB 오류가 발생했다면 Firebase Profile 삭제

--- a/backend/src/controller/inquire.controller.ts
+++ b/backend/src/controller/inquire.controller.ts
@@ -10,10 +10,9 @@ import { InquireImage } from "../model/inquireImage.model";
 import { Solution } from "../model/solution.model";
 
 import logger from "../logger/logger";
-import { deleteFile, deleteFolder, getAllFiles, uploadFile } from "../util/firebase";
+import { deleteFile, deleteFolder, uploadFile } from "../util/firebase";
 import { SolutionImage } from "../model/solutionImage.model";
 import { Transaction } from "sequelize";
-import { ErrorImage } from "../model/errorImage.model";
 
 const folderName = "users";
 
@@ -186,16 +185,6 @@ const controller = {
             if (inquireImage.length > 0) {
                 const path = `${folderName}/${inquire.userId}/inquires/${inquireId}`;
                 await deleteFolder(path);
-                const images = await getAllFiles(path);
-
-                // 지워지지 않은 이미지가 존재할 시
-                if (images.items.length) {
-                    images.items.forEach(async (image) => {
-                        logger.warn(`Image not deleted, Inquire Id : ${inquire.inquireId} => ${image.fullPath}`);
-
-                        await ErrorImage.create({ path: image.fullPath });
-                    });
-                }
             }
 
             transaction.commit();

--- a/backend/src/controller/inquire.controller.ts
+++ b/backend/src/controller/inquire.controller.ts
@@ -14,7 +14,7 @@ import { deleteFile, deleteFolder, uploadFile } from "../util/firebase";
 import { SolutionImage } from "../model/solutionImage.model";
 import { Transaction } from "sequelize";
 
-const folderName = "users";
+const FOLDER_NAME = "users";
 
 /**
  * inquireImage 다중 Image 생성 및 변경을 해주는 함수
@@ -30,7 +30,7 @@ const uploads = async (inquireId: number, userId: number, imageData: File | File
         if (imageData instanceof Array<File>) {
             for (let i = 0; i < imageData.length; i++) {
                 const image = imageData[i];
-                const path = `${folderName}/${userId}/inquires/${inquireId}/${dayjs().valueOf()}.${image.originalFilename}`;
+                const path = `${FOLDER_NAME}/${userId}/inquires/${inquireId}/${dayjs().valueOf()}.${image.originalFilename}`;
 
                 await uploadFile(path, image.filepath);
                 firebaseUploads.push(path);
@@ -46,7 +46,7 @@ const uploads = async (inquireId: number, userId: number, imageData: File | File
                 logger.debug(`Create Inquire Image => ${path}`);
             }
         } else if (imageData instanceof File) {
-            const path = `${folderName}/${userId}/inquires/${inquireId}/${dayjs().valueOf()}.${imageData.originalFilename}`;
+            const path = `${FOLDER_NAME}/${userId}/inquires/${inquireId}/${dayjs().valueOf()}.${imageData.originalFilename}`;
 
             await uploadFile(path, imageData.filepath);
             firebaseUploads.push(path);
@@ -183,7 +183,7 @@ const controller = {
             await inquire.destroy({ transaction });
 
             if (inquireImage.length > 0) {
-                const path = `${folderName}/${inquire.userId}/inquires/${inquireId}`;
+                const path = `${FOLDER_NAME}/${inquire.userId}/inquires/${inquireId}`;
                 await deleteFolder(path);
             }
 

--- a/backend/src/controller/user.admin.controller.ts
+++ b/backend/src/controller/user.admin.controller.ts
@@ -303,7 +303,7 @@ const controller = {
             // 이미 profile이 있다면 Firebase에서 삭제
             if (prevProfile && data.profile) {
                 await deleteFile(prevProfile);
-                logger.debug(`Deleted already profile => ${prevProfile}`);
+                logger.debug(`Deleted Previous Profile => ${prevProfile}`);
             }
 
             transaction.commit();
@@ -385,15 +385,7 @@ const controller = {
         users.forEach(async (user: User) => {
             const profile: string | null = user.profile;
 
-            if (profile) {
-                try {
-                    await deleteFile(profile);
-                } catch (_error) {
-                    logger.warn(`User Image not deleted : ${user.userId} => ${profile}`);
-                    await ErrorImage.create({ path: profile });
-                }
-            }
-
+            if (profile) await deleteFile(profile);
             await user.destroy();
         });
     }

--- a/backend/src/controller/user.admin.controller.ts
+++ b/backend/src/controller/user.admin.controller.ts
@@ -358,7 +358,7 @@ const controller = {
         userHasInquiry.forEach(async (user: User) => {
             user.inquires!.forEach(async (inquire: Inquire) => {
                 await inquireController.deleteInquire(inquire.inquireId);
-                // soluton 삭제
+                // soluton image 삭제
                 // if (inquire.solution) await solutionController.deleteSolution(inquire.solution.solutionId);
             });
         });

--- a/backend/src/controller/user.controller.ts
+++ b/backend/src/controller/user.controller.ts
@@ -173,7 +173,7 @@ const controller = {
             // 이미 profile이 있다면 Firebase에서 삭제
             if (prevProfile && data.profile) {
                 await deleteFile(prevProfile);
-                logger.debug(`Deleted already profile => ${prevProfile}`);
+                logger.debug(`Deleted Previous Profile => ${prevProfile}`);
             }
         } catch (error) {
             // Firebase에는 업로드 되었지만 DB 오류가 발생했다면 Firebase Profile 삭제

--- a/backend/src/model/albnmImage.model.ts
+++ b/backend/src/model/albnmImage.model.ts
@@ -33,7 +33,7 @@ AlbumImage.init(
             }
         },
         image: {
-            type: DataTypes.STRING(60),
+            type: DataTypes.STRING(200),
             allowNull: false
         },
         createdTime: {

--- a/backend/src/model/albnmImage.model.ts
+++ b/backend/src/model/albnmImage.model.ts
@@ -1,0 +1,56 @@
+import dayjs from "dayjs";
+import { DataTypes, Model, literal } from "sequelize";
+import { CreationOptional, InferAttributes, InferCreationAttributes } from "sequelize/types/model";
+
+import sequelize from ".";
+import { Album } from "./album.model";
+
+// -------------------------------------------- Interface ------------------------------------------ //
+// ------------------------------------------ Interface End ---------------------------------------- //
+
+export class AlbumImage extends Model<InferAttributes<AlbumImage>, InferCreationAttributes<AlbumImage>> {
+    declare imageId: CreationOptional<number>;
+    declare albumId: number;
+    declare image: string;
+    declare createdTime: CreationOptional<Date>;
+}
+
+AlbumImage.init(
+    {
+        imageId: {
+            field: "image_id",
+            type: DataTypes.INTEGER.UNSIGNED,
+            autoIncrement: true,
+            primaryKey: true
+        },
+        albumId: {
+            field: "album_id",
+            type: DataTypes.INTEGER.UNSIGNED,
+            allowNull: false,
+            references: {
+                model: Album,
+                key: "album_id"
+            }
+        },
+        image: {
+            type: DataTypes.STRING(60),
+            allowNull: false
+        },
+        createdTime: {
+            field: "created_time",
+            type: "TIMESTAMP",
+            defaultValue: literal("CURRENT_TIMESTAMP"),
+            get(this: AlbumImage): string | null {
+                const date = dayjs(this.getDataValue("createdTime"));
+                const formatDate = date.format("YYYY-MM-DD HH:mm:ss");
+
+                return date.isValid() ? formatDate : null;
+            }
+        }
+    },
+    {
+        sequelize: sequelize,
+        tableName: "album_image",
+        timestamps: false
+    }
+);

--- a/backend/src/model/album.model.ts
+++ b/backend/src/model/album.model.ts
@@ -41,6 +41,31 @@ export interface IResponse {
     items: string[];
     nextPageToken?: string;
 }
+// -------------------------------------------- Admin ------------------------------------------ //
+export interface IAlbumResponseWithCount {
+    albums: Album[];
+    count: number;
+}
+
+export interface PageOptions {
+    count: number;
+    page: number;
+    sort: string | "r" | "o" | "cd" | "ca";
+}
+
+export interface SearchOptions {
+    cupId?: string;
+}
+
+export interface FilterOptions {
+    fromDate?: Date;
+    toDate?: Date;
+}
+
+export interface IUpdate {
+    title?: string;
+    thumbnail: string;
+}
 // ------------------------------------------ Interface End ---------------------------------------- //
 
 export class Album extends Model<InferAttributes<Album>, InferCreationAttributes<Album>> {

--- a/backend/src/model/album.model.ts
+++ b/backend/src/model/album.model.ts
@@ -1,9 +1,10 @@
 import dayjs from "dayjs";
 import { File } from "formidable";
-import { DataTypes, Model, literal, NonAttribute } from "sequelize";
+import { DataTypes, Model, literal, NonAttribute, HasManyGetAssociationsMixin } from "sequelize";
 import { CreationOptional, InferAttributes, InferCreationAttributes } from "sequelize/types/model";
 
 import sequelize from ".";
+import { AlbumImage } from "./albnmImage.model";
 import { Couple } from "./couple.model";
 // -------------------------------------------- Interface ------------------------------------------ //
 export interface ICreate {
@@ -14,8 +15,8 @@ export interface ICreate {
 export interface IRequestGet {
     albumId: number;
     cupId: string;
+    page: number;
     count: number;
-    nextPageToken?: string;
 }
 
 export interface IRequestUpadteTitle {
@@ -38,8 +39,8 @@ export interface IResponse {
     title: string;
     thumbnail: string | null;
     createdTime: Date;
-    items: string[];
-    nextPageToken?: string;
+    images: AlbumImage[];
+    total: number;
 }
 // -------------------------------------------- Admin ------------------------------------------ //
 export interface IAlbumResponseWithCount {
@@ -69,6 +70,8 @@ export interface IUpdate {
 // ------------------------------------------ Interface End ---------------------------------------- //
 
 export class Album extends Model<InferAttributes<Album>, InferCreationAttributes<Album>> {
+    /** If you use include inquireImage, You can use inquireImages field. */
+    declare albumImages?: NonAttribute<AlbumImage[]>;
     /** If you use include couple, You can use couple field. */
     declare couple?: NonAttribute<Couple>;
 
@@ -77,6 +80,8 @@ export class Album extends Model<InferAttributes<Album>, InferCreationAttributes
     declare title: string;
     declare thumbnail: CreationOptional<string | null>;
     declare createdTime: CreationOptional<Date>;
+
+    declare getAlbumImages: HasManyGetAssociationsMixin<AlbumImage>;
 }
 
 Album.init(

--- a/backend/src/model/album.model.ts
+++ b/backend/src/model/album.model.ts
@@ -64,6 +64,8 @@ export interface FilterOptions {
 }
 
 export interface IAdminUpdate {
+    cupId: string;
+    albumId: number;
     title?: string;
 }
 // ------------------------------------------ Interface End ---------------------------------------- //

--- a/backend/src/model/album.model.ts
+++ b/backend/src/model/album.model.ts
@@ -105,7 +105,7 @@ Album.init(
             allowNull: false
         },
         thumbnail: {
-            type: DataTypes.STRING(60)
+            type: DataTypes.STRING(200)
         },
         createdTime: {
             field: "created_time",

--- a/backend/src/model/album.model.ts
+++ b/backend/src/model/album.model.ts
@@ -45,7 +45,7 @@ export interface IResponse {
 // -------------------------------------------- Admin ------------------------------------------ //
 export interface IAlbumResponseWithCount {
     albums: Album[];
-    count: number;
+    total: number;
 }
 
 export interface PageOptions {
@@ -63,9 +63,8 @@ export interface FilterOptions {
     toDate?: Date;
 }
 
-export interface IUpdate {
+export interface IAdminUpdate {
     title?: string;
-    thumbnail: string;
 }
 // ------------------------------------------ Interface End ---------------------------------------- //
 

--- a/backend/src/model/association.config.ts
+++ b/backend/src/model/association.config.ts
@@ -1,3 +1,4 @@
+import { AlbumImage } from "./albnmImage.model";
 import { Album } from "./album.model";
 import { Calendar } from "./calendar.model";
 import { Couple } from "./couple.model";
@@ -68,6 +69,18 @@ export default {
             foreignKey: "cupId",
             onDelete: "CASCADE",
             as: "couple"
+        });
+
+        // ------------------------------------------ Album to AlbumImage --------------------------------------- //
+        Album.hasMany(AlbumImage, {
+            foreignKey: "albumId",
+            as: "albumImages"
+        });
+
+        AlbumImage.belongsTo(Album, {
+            foreignKey: "albumId",
+            onDelete: "CASCADE",
+            as: "album"
         });
 
         // ------------------------------------------ Calendar to Couple ---------------------------------------- //

--- a/backend/src/model/couple.model.ts
+++ b/backend/src/model/couple.model.ts
@@ -87,7 +87,7 @@ Couple.init(
             allowNull: false
         },
         thumbnail: {
-            type: DataTypes.STRING(60)
+            type: DataTypes.STRING(200)
         },
         createdTime: {
             field: "created_time",

--- a/backend/src/model/errorImage.model.ts
+++ b/backend/src/model/errorImage.model.ts
@@ -19,7 +19,7 @@ ErrorImage.init(
             primaryKey: true
         },
         path: {
-            type: DataTypes.STRING(60)
+            type: DataTypes.STRING(200)
         },
         createdTime: {
             field: "created_time",

--- a/backend/src/model/inquireImage.model.ts
+++ b/backend/src/model/inquireImage.model.ts
@@ -36,7 +36,7 @@ InquireImage.init(
             }
         },
         image: {
-            type: DataTypes.STRING(60),
+            type: DataTypes.STRING(200),
             allowNull: false
         },
         createdTime: {

--- a/backend/src/model/noticeImage.model.ts
+++ b/backend/src/model/noticeImage.model.ts
@@ -36,7 +36,7 @@ NoticeImage.init(
             }
         },
         image: {
-            type: DataTypes.STRING(60),
+            type: DataTypes.STRING(200),
             allowNull: false
         },
         createdTime: {

--- a/backend/src/model/solutionImage.model.ts
+++ b/backend/src/model/solutionImage.model.ts
@@ -36,7 +36,7 @@ SolutionImage.init(
             }
         },
         image: {
-            type: DataTypes.STRING(60),
+            type: DataTypes.STRING(200),
             allowNull: false
         },
         createdTime: {

--- a/backend/src/model/user.model.ts
+++ b/backend/src/model/user.model.ts
@@ -178,7 +178,7 @@ User.init(
             allowNull: false
         },
         profile: {
-            type: DataTypes.STRING(60)
+            type: DataTypes.STRING(200)
         },
         primaryNofi: {
             field: "primary_nofi",

--- a/backend/src/routes/album.admin.ts
+++ b/backend/src/routes/album.admin.ts
@@ -1,0 +1,65 @@
+import dayjs from "dayjs";
+import joi, { ValidationResult } from "joi";
+import express, { Router, Request, Response, NextFunction } from "express";
+import formidable, { File } from "formidable";
+import { boolean } from "boolean";
+
+import { IAlbumResponseWithCount, PageOptions, SearchOptions, FilterOptions, IRequestGet, IUpdate } from "../model/album.model";
+
+import coupleController from "../controller/couple.controller";
+import albumAdminController from "../controller/album.admin.controller";
+
+import logger from "../logger/logger";
+import validator from "../util/validator";
+import StatusCode from "../util/statusCode";
+import { canModifyWithEditor, canView } from "../util/checkRole";
+
+import BadRequestError from "../error/badRequest";
+import ForbiddenError from "../error/forbidden";
+import InternalServerError from "../error/internalServer";
+
+const router: Router = express.Router();
+
+const signupSchema: joi.Schema = joi.object({
+    userId2: joi.number().required(),
+    title: joi.string().required(),
+    cupDay: joi.date().required()
+});
+
+const updateSchema: joi.Schema = joi.object({
+    title: joi.string(),
+    cupDay: joi.date()
+});
+
+router.get("/", canView, async (req: Request, res: Response, next: NextFunction) => {
+    const pageOptions: PageOptions = {
+        count: Number(req.query.count) || 10,
+        page: Number(req.query.page) || 1,
+        sort: String(req.query.sort) || "r"
+    };
+    const searchOptions: SearchOptions = {
+        cupId: req.query.cup_id ? String(req.query.cup_id) : undefined
+    };
+    const filterOptions: FilterOptions = {
+        fromDate: req.query.from_date ? new Date(dayjs(String(req.query.from_date)).valueOf()) : undefined,
+        toDate: req.query.to_date ? new Date(dayjs(String(req.query.to_date)).add(1, "day").valueOf()) : undefined
+    };
+
+    try {
+        const result: IAlbumResponseWithCount = await albumAdminController.getAlbumFolders(pageOptions, searchOptions, filterOptions);
+
+        logger.debug(`Response Data => ${JSON.stringify(result)}`);
+        return res.status(StatusCode.OK).json(result);
+    } catch (error) {
+        next(error);
+    }
+});
+
+// Create Couple
+router.post("/", canModifyWithEditor, async (req: Request, res: Response, next: NextFunction) => {});
+
+router.patch("/:cup_id", canModifyWithEditor, async (req: Request, res: Response, next: NextFunction) => {});
+
+router.delete("/:couple_ids", canModifyWithEditor, async (req: Request, res: Response, next: NextFunction) => {});
+
+export default router;

--- a/backend/src/routes/album.admin.ts
+++ b/backend/src/routes/album.admin.ts
@@ -2,9 +2,8 @@ import dayjs from "dayjs";
 import joi, { ValidationResult } from "joi";
 import express, { Router, Request, Response, NextFunction } from "express";
 import formidable, { File } from "formidable";
-import { boolean } from "boolean";
 
-import { IAlbumResponseWithCount, PageOptions, SearchOptions, FilterOptions, IRequestGet, IUpdate } from "../model/album.model";
+import { IAlbumResponseWithCount, PageOptions, SearchOptions, FilterOptions, IRequestGet, ICreate } from "../model/album.model";
 
 import coupleController from "../controller/couple.controller";
 import albumAdminController from "../controller/album.admin.controller";
@@ -20,15 +19,9 @@ import InternalServerError from "../error/internalServer";
 
 const router: Router = express.Router();
 
-const signupSchema: joi.Schema = joi.object({
-    userId2: joi.number().required(),
-    title: joi.string().required(),
-    cupDay: joi.date().required()
-});
-
-const updateSchema: joi.Schema = joi.object({
-    title: joi.string(),
-    cupDay: joi.date()
+const createSchema: joi.Schema = joi.object({
+    cupId: joi.string().required(),
+    title: joi.string().required()
 });
 
 router.get("/", canView, async (req: Request, res: Response, next: NextFunction) => {
@@ -55,8 +48,34 @@ router.get("/", canView, async (req: Request, res: Response, next: NextFunction)
     }
 });
 
-// Create Couple
-router.post("/", canModifyWithEditor, async (req: Request, res: Response, next: NextFunction) => {});
+router.post("/:cup_id", canModifyWithEditor, async (req: Request, res: Response, next: NextFunction) => {
+    const form = formidable({ multiples: true, maxFieldsSize: 5 * 1024 * 1024, maxFiles: 101 });
+
+    form.parse(req, async (err, fields, files) => {
+        try {
+            req.body = Object.assign({}, req.body, fields);
+            req.body.cupId = req.params.cup_id ? String(req.params.cup_id) : undefined;
+            const { value, error }: ValidationResult = validator(req.body, createSchema);
+
+            if (err) throw err;
+            else if (error) throw new BadRequestError(error.message);
+            else if (files.thumbnail instanceof Array<formidable.File>) throw new BadRequestError("You must have only one thumbnail.");
+
+            const data: ICreate = {
+                cupId: req.body.cupId,
+                title: String(req.body.title)
+            };
+            const thumbnail: File | undefined = files.thumbnail;
+            const images: File | File[] | undefined = files.images;
+
+            await albumAdminController.addAlbum(data, thumbnail, images);
+
+            res.status(StatusCode.CREATED).json({});
+        } catch (error) {
+            next(error);
+        }
+    });
+});
 
 router.patch("/:cup_id", canModifyWithEditor, async (req: Request, res: Response, next: NextFunction) => {});
 

--- a/backend/src/routes/album.ts
+++ b/backend/src/routes/album.ts
@@ -36,18 +36,17 @@ router.get("/:cup_id", async (req: Request, res: Response, next: NextFunction) =
 router.get("/:cup_id/:album_id", async (req: Request, res: Response, next: NextFunction) => {
     try {
         const albumId = Number(req.params.album_id);
-        let count = Number(req.query.count);
-        const nextPageToken = req.query.nextPageToken ? String(req.query.nextPageToken) : undefined;
+        const page = !isNaN(Number(req.query.page)) ? Number(req.query.page) : 1;
+        const count = !isNaN(Number(req.query.count)) ? Number(req.query.count) : 50;
 
         if (req.body.cupId !== req.params.cup_id) throw new ForbiddenError("Not Same Couple Id");
         else if (isNaN(albumId)) throw new BadRequestError("Bad Request Error");
-        else if (isNaN(count)) count = 50;
 
         const data: IRequestGet = {
             albumId: albumId,
             cupId: req.body.cupId,
-            count: count,
-            nextPageToken: nextPageToken
+            page: page,
+            count: count
         };
         const result: IResponse = await albumController.getAlbums(data);
 

--- a/backend/src/routes/couple.admin.ts
+++ b/backend/src/routes/couple.admin.ts
@@ -55,7 +55,7 @@ router.get("/", canView, async (req: Request, res: Response, next: NextFunction)
     };
 
     try {
-        const result: ICoupleResponseWithCount = await coupleAdminController.getCouple(pageOptions, searchOptions, filterOptions);
+        const result: ICoupleResponseWithCount = await coupleAdminController.getCouples(pageOptions, searchOptions, filterOptions);
 
         logger.debug(`Response Data => ${JSON.stringify(result)}`);
         return res.status(StatusCode.OK).json(result);
@@ -128,6 +128,16 @@ router.patch("/:cup_id", canModifyWithEditor, async (req: Request, res: Response
     });
 });
 
-router.delete("/:couple_ids", canModifyWithEditor, async (req: Request, res: Response, next: NextFunction) => {});
+router.delete("/:couple_ids", canModifyWithEditor, async (req: Request, res: Response, next: NextFunction) => {
+    const coupleIds: string[] = req.params.couple_ids.split(",");
+
+    try {
+        await coupleAdminController.deleteCouples(coupleIds);
+
+        res.status(StatusCode.NO_CONTENT).json({});
+    } catch (error) {
+        next(error);
+    }
+});
 
 export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -10,6 +10,7 @@ import noticeRouter from "./notice";
 
 import userAdminRouter from "./user.admin";
 import coupleAdminRouter from "./couple.admin";
+import albumAdminRouter from "./album.admin";
 
 import authMiddleware from "../middlewares/auth.middleware";
 
@@ -26,5 +27,6 @@ router.use("/inquire", authMiddleware, inquireRouter);
 
 router.use("/admin/user", authMiddleware, userAdminRouter);
 router.use("/admin/couple", authMiddleware, coupleAdminRouter);
+router.use("/admin/album", authMiddleware, albumAdminRouter);
 
 export default router;

--- a/backend/src/util/checkRole.ts
+++ b/backend/src/util/checkRole.ts
@@ -10,7 +10,6 @@ export const canModifyWithAdmin = (req: Request, _res: Response, next: NextFunct
 
 export const canModifyWithEditor = (req: Request, _res: Response, next: NextFunction) => {
     const role: number = Number(req.body.role);
-    console.log(role);
 
     if (role !== 1 && role !== 2) throw new ForbiddenError("Unauthorized Access");
     else next();

--- a/backend/src/util/firebase.ts
+++ b/backend/src/util/firebase.ts
@@ -87,7 +87,7 @@ export const deleteFile = async (path: string): Promise<void> => {
     } catch (error) {
         const images: ListResult = await getAllFiles(path);
 
-        if ((images.items.length && images.items.length > 0) || (error instanceof FirebaseError && error.code === "storage/object-not-found")) {
+        if ((error instanceof FirebaseError && error.code === "storage/object-not-found") || (images.items.length && images.items.length > 0)) {
             try {
                 if (error instanceof Error) logger.warn(`Image not deleted : ${path} => ${error.stack}`);
                 else logger.warn(`Image not deleted : ${path} => ${new Error().stack}`);

--- a/backend/src/util/firebase.ts
+++ b/backend/src/util/firebase.ts
@@ -103,7 +103,6 @@ export const deleteFile = async (path: string): Promise<void> => {
  * Firebase Storage 폴더를 삭제합니다.
  * 만약 Firebase 문제가 아닌 모종의 이유로 삭제가 되지 않았다면 ErrorImage Table에 추가됩니다.
  * @param path 폴더 경로
- * @param folderName 폴더 이름
  */
 export const deleteFolder = async (path: string): Promise<void> => {
     const folderRef = ref(storage, path);

--- a/backend/src/util/firebase.ts
+++ b/backend/src/util/firebase.ts
@@ -112,6 +112,8 @@ export const uploadFile = async (path: string, filePath: string): Promise<void> 
 
 /**
  * Firebase Storage를 통해 이미지를 삭제합니다.
+ * 만약 Firebase 문제가 아닌 모종의 이유로 삭제가 되지 않았다면 ErrorImage Table에 추가됩니다.
+ * 대신, Firebase 자체에 문제가 생겼다면 Error를 반환합니다.
  * @param path 이미지 경로
  * @param folderName Firebase Storage 폴더 이름
  */
@@ -131,6 +133,8 @@ export const deleteFile = async (path: string): Promise<void> => {
 
 /**
  * Firebase Storage 폴더를 삭제합니다.
+ * 만약 Firebase 문제가 아닌 모종의 이유로 삭제가 되지 않았다면 ErrorImage Table에 추가됩니다.
+ * 대신, Firebase 자체에 문제가 생겼다면 Error를 반환합니다.
  * @param path 폴더 경로
  * @param folderName 폴더 이름
  */
@@ -147,7 +151,7 @@ export const deleteFolder = async (path: string): Promise<void> => {
      * Promise.all => N개의 Promise를 수행 중 하나라도 거부(reject) 당하면 바로 에러를 반환
      * Promise.allSettled => 이행/거부 여부와 관계없이 주어진 Promise가 모두 완료될 때 까지 기달림
      */
-    // await Promise.allSettled(promises);
+    await Promise.allSettled(promises);
 
     const images = await getAllFiles(path);
 

--- a/backend/src/util/firebase.ts
+++ b/backend/src/util/firebase.ts
@@ -87,15 +87,17 @@ export const deleteFile = async (path: string): Promise<void> => {
     } catch (error) {
         const images: ListResult = await getAllFiles(path);
 
-        if (images.items.length && images.items.length > 0) {
+        if ((images.items.length && images.items.length > 0) || (error instanceof FirebaseError && error.code === "storage/object-not-found")) {
             try {
                 if (error instanceof Error) logger.warn(`Image not deleted : ${path} => ${error.stack}`);
                 else logger.warn(`Image not deleted : ${path} => ${new Error().stack}`);
             } catch (_error) {}
-            await ErrorImage.create({ path: path });
-        }
 
-        throw error;
+            await ErrorImage.create({ path: path });
+            return;
+        } else {
+            throw error;
+        }
     }
 };
 


### PR DESCRIPTION
1. Couple Admin Delete API 완성
2. Album Images Table 생성 (앨범 안에 이미지 총 개수 및 관리하기 편하게 할 수 있도록 변경)
3. Album Admin Get API 완성
4. Album Admin Post API 완성 (앨범 제목, 썸네일, 앨범 이미지)
5. Album Admin Images Post API 완성 (앨범 이미지)
6. Album Update API 완성 (앨범 제목, 썸네일)
7. Album Get 할 시 Folder의 총 total count를 뿌려줌
8. Firebase Delete File에서 not found error가 뜨면 error_image로 추가 및 무시 (error_image에만 넣고 나머지는 정상적으로 수행)
9. Firebase Delete Folder 시 삭제 처리 여부를 확인하여 지워지지 않은 이미지는 error_image에 추가 (allSettled는 무조건 resolve한 상황이 나오는게 아니기 때문에 전체적으로 확인)